### PR TITLE
Fix startup script for existing raft storage demo

### DIFF
--- a/raft-ha-storage/existing_server/cluster.sh
+++ b/raft-ha-storage/existing_server/cluster.sh
@@ -253,7 +253,10 @@ function setup_vault_1 {
 
   set -aex
   # Kill all previous server instances
-  ps aux | grep "vault server" | grep -v grep | awk '{print $2}' | xargs kill
+  previous=$(ps aux | grep "vault server" | grep -v grep | awk '{print $2}')
+  if [ -n "$previous" ]; then
+     echo "$previous" | xargs kill
+  fi
 
   rm -rf "$demo_home"/vault-raft-file
   mkdir -pm 0755 "$demo_home"/vault-raft-file


### PR DESCRIPTION
The script would fail when there is no server already started on Linux. MacOS appears to handle automatically the issue when an empty argument is sent to `xargs`. 

This PR solves the issue by checking first if the previous server list is empty. 